### PR TITLE
Fix README for non compiling sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ func main() {
   defer p.Close()
 
   buf := make([]byte, 1)
-  if c, err := p.Read(buf); err != nil {
+  if _, err := p.Read(buf); err != nil {
     log.Panic(err)
   } else {
     log.Println(buf)


### PR DESCRIPTION
When building the sample you get:

    > ./main.go:19:5: c declared and not used

Fixed it to contain a fully working example.