### PR TITLE
Blocking read now returns when device is unplugged. i.e. device node is removed

### DIFF
--- a/serialport.c
+++ b/serialport.c
@@ -970,6 +970,9 @@ SP_API enum sp_return sp_blocking_read(struct sp_port *port, void *buf,
 			else
 				/* This is an actual failure. */
 				RETURN_FAIL("read() failed");
+		} else if (result == 0) {
+			/* unexpected EOF */
+			RETURN_FAIL("Unexpected EOF");
 		}
 
 		bytes_read += result;


### PR DESCRIPTION
Block read calls keeps blocking even when the device node disappears. This happens when an Arduino is unplugged. Fixed, by returning a failure when EOF is returned by read(). I.e. the serial port is closed.
